### PR TITLE
Improve CLI descriptions

### DIFF
--- a/src/state/__main__.py
+++ b/src/state/__main__.py
@@ -19,21 +19,22 @@ from ._cli import (
 def get_args() -> tuple[ap.Namespace, list[str]]:
     """Parse known args and return remaining args for Hydra overrides"""
     desc = """description:
-  STATE command line interface.
-  For more information on how to use the CLI, use the `state <command> --help` command."""
+  Entry point for the STATE command line interface.
+  Use these commands to train models, compute embeddings, and run inference.
+  Run `state <command> --help` for details on each command."""
     parser = ap.ArgumentParser(description=desc, formatter_class=CustomFormatter)
     subparsers = parser.add_subparsers(required=True, dest="command")
 
     # emb
     desc = """description:
-  Embedding commands.
-  For more information on how to use the CLI, use the `state emb <command> --help` command."""
+  Commands for generating and querying STATE embeddings.
+  See `state emb <command> --help` for subcommand options."""
     add_arguments_emb(subparsers.add_parser("emb", description=desc, formatter_class=CustomFormatter))
 
     # tx
     desc = """description:
-  Transcriptomic commands.
-  For more information on how to use the CLI, use the `state tx <command> --help` command."""
+  Train and evaluate perturbation models with Hydra configuration.
+  Overrides can be passed via `state tx <subcommand> param=value`."""
     add_arguments_tx(subparsers.add_parser("tx", description=desc, formatter_class=CustomFormatter))
 
     # Use parse_known_args to get both known args and remaining args
@@ -74,21 +75,20 @@ def show_hydra_help(method: str):
     print()
     print("Usage examples:")
     print("  Override single parameter:")
-    print(f"    uv run state tx train data.batch_size=64")
+    print("    uv run state tx train data.batch_size=64")
     print()
     print("  Override nested parameter:")
-    print(f"    uv run state tx train model.kwargs.hidden_dim=512")
+    print("    uv run state tx train model.kwargs.hidden_dim=512")
     print()
     print("  Override multiple parameters:")
-    print(f"    uv run state tx train data.batch_size=64 training.lr=0.001")
+    print("    uv run state tx train data.batch_size=64 training.lr=0.001")
     print()
     print("  Change config group:")
-    print(f"    uv run state tx train data=custom_data model=custom_model")
+    print("    uv run state tx train data=custom_data model=custom_model")
     print()
     print("Available config groups:")
     
     # Show available config groups
-    import os
     from pathlib import Path
     
     config_dir = Path(__file__).parent / "configs"

--- a/src/state/_cli/_emb/__init__.py
+++ b/src/state/_cli/_emb/__init__.py
@@ -14,16 +14,23 @@ def add_arguments_emb(parser: ap.ArgumentParser):
 
     # fit
     desc = """description:
-  Fit an embedding model to a dataset."""
-    add_arguments_fit(subparsers.add_parser("fit", description=desc, formatter_class=CustomFormatter))
+  Train an embedding model on a reference dataset.
+  Provide Hydra overrides to adjust training parameters."""
+    add_arguments_fit(
+        subparsers.add_parser("fit", description=desc, formatter_class=CustomFormatter)
+    )
 
     # transform
     desc = """description:
-  Transform a dataset into an embedding.
-  You can also create or add embeddings to a LanceDB database."""
-    add_arguments_transform(subparsers.add_parser("transform", description=desc, formatter_class=CustomFormatter))
+  Encode an input dataset with a trained embedding model.
+  Results can be saved locally or inserted into a LanceDB database."""
+    add_arguments_transform(
+        subparsers.add_parser("transform", description=desc, formatter_class=CustomFormatter)
+    )
 
     # query
     desc = """description:
-  Query a LanceDB database for similar cells."""
-    add_arguments_query(subparsers.add_parser("query", description=desc, formatter_class=CustomFormatter))
+  Search a LanceDB vector store for cells with matching embeddings."""
+    add_arguments_query(
+        subparsers.add_parser("query", description=desc, formatter_class=CustomFormatter)
+    )

--- a/src/state/_cli/_emb/_query.py
+++ b/src/state/_cli/_emb/_query.py
@@ -131,5 +131,5 @@ def create_result_anndata(query_adata, results_df, k):
     # Create result anndata
     result_adata = query_adata.copy()
     result_adata.uns['lancedb_query_results'] = uns_data
-    
+
     return result_adata

--- a/src/state/_cli/_tx/__init__.py
+++ b/src/state/_cli/_tx/__init__.py
@@ -14,21 +14,23 @@ def add_arguments_tx(parser: ap.ArgumentParser):
 
     # Train
     desc = """description:
-  Train a model using the specified configuration.
-  Use `hydra_overrides` to pass additional configuration overrides.
-
-  For example, to use a different model architecture:
-  ```
-  state tx train data.batch_size=32 model.kwargs.cell_set_len=64
-  ```"""
-    add_arguments_train(subparsers.add_parser("train", description=desc, formatter_class=CustomFormatter))
+  Train a perturbation model using a Hydra configuration.
+  Provide overrides to customize training, e.g.:
+  `state tx train data.batch_size=32`"""
+    add_arguments_train(
+        subparsers.add_parser("train", description=desc, formatter_class=CustomFormatter)
+    )
 
     # Predict
     desc = """description:
-  Predict transcriptomic data using a trained model."""
-    add_arguments_predict(subparsers.add_parser("predict", description=desc, formatter_class=CustomFormatter))
+  Generate predictions from a trained model and optionally compute evaluation metrics."""
+    add_arguments_predict(
+        subparsers.add_parser("predict", description=desc, formatter_class=CustomFormatter)
+    )
 
     # Infer
     desc = """description:
-  Infer transcriptomic data from input samples."""
-    add_arguments_infer(subparsers.add_parser("infer", description=desc, formatter_class=CustomFormatter))
+  Run inference on new samples using a trained model."""
+    add_arguments_infer(
+        subparsers.add_parser("infer", description=desc, formatter_class=CustomFormatter)
+    )

--- a/src/state/_cli/_utils.py
+++ b/src/state/_cli/_utils.py
@@ -1,5 +1,8 @@
 import argparse
 
-class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
-                      argparse.RawDescriptionHelpFormatter):
+class CustomFormatter(
+    argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
+):
+    """Combine default and raw formatting styles."""
+
     pass


### PR DESCRIPTION
## Summary
- clarify CLI entry description
- expand text about embedding commands
- expand text about transcriptomic commands
- tidy the query command implementation
- document custom formatter

## Testing
- `ruff check src/state/_cli/_utils.py src/state/_cli/_emb/__init__.py src/state/_cli/_emb/_query.py src/state/_cli/_tx/__init__.py src/state/__main__.py`

------
https://chatgpt.com/codex/tasks/task_b_6880fd6ccd2083299594581251a1e384